### PR TITLE
Fixes typo in negotiate response

### DIFF
--- a/lib/src/http_connection.dart
+++ b/lib/src/http_connection.dart
@@ -61,7 +61,7 @@ extension NegotiateResponseExtensions on NegotiateResponse {
         availableTransports: AvailableTransportExtensions.listFromJson(
             json['availableTransports']),
         url: json['url'],
-        accessToken: json['accessToekn'],
+        accessToken: json['accessToken'],
         error: json['error']);
   }
 }


### PR DESCRIPTION
When first negotiate response returned access token and url, the next access token was incorrectly assigned to property. That cause the second negotiate response returning 401 Unauthorized.

This PR fixes the typo in NegotiateResponseExtension.