### PR TITLE
Fix retry attempts not waiting

### DIFF
--- a/lib/src/hub_connection.dart
+++ b/lib/src/hub_connection.dart
@@ -409,9 +409,11 @@ class HubConnection {
       _logger(LogLevel.information,
           'Reconnect attempt number ${previousReconnectAttempts} will start in ${nextRetryDelay} ms.');
 
-      await Future.value((resolve) async {
-        _reconnectDelayHandle =
-            Timer.periodic(Duration(milliseconds: nextRetryDelay), resolve);
+      await Future(() {
+        Completer completer = Completer();
+        _reconnectDelayHandle = Timer(
+            Duration(milliseconds: nextRetryDelay), () => completer.complete());
+        return completer.future;
       });
       _reconnectDelayHandle = null;
 


### PR DESCRIPTION
When using automatic reconnection the timer doesn't get waited on, this causes the reconnection attempts to run straight after the last one failed

This PR changes the Future to wait for the timer to complete before it tries again