### PR TITLE
Correctly appends ID query parameter to the existing ones

### DIFF
--- a/lib/src/http_connection.dart
+++ b/lib/src/http_connection.dart
@@ -445,9 +445,19 @@ class HttpConnection implements Connection {
     if (connectionToken == null) {
       return url;
     }
-    // TODO: Look at this...
-    //return url + '?' + 'id=$connectionToken';
-    return url + (!url.contains('?') ? '?' : '&') + 'id=$connectionToken';
+
+    final uri = Uri.parse(url);
+
+    return Uri(
+      scheme: uri.scheme,
+      host: uri.host,
+      path: uri.path,
+      fragment: uri.fragment,
+      queryParameters: <String, dynamic>{
+        ...uri.queryParameters,
+        ...{ 'id': connectionToken },
+      },
+    ).toString();
   }
 
   Future<void> _createTransport(

--- a/lib/src/http_connection.dart
+++ b/lib/src/http_connection.dart
@@ -446,7 +446,10 @@ class HttpConnection implements Connection {
       return url;
     }
 
-    final uri = Uri.parse(url);
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return url;
+    }
 
     return Uri(
       scheme: uri.scheme,


### PR DESCRIPTION
Fixes #22. Fixes #13. It parses `url` into `Uri` and then returns a new `Uri` with new parameters which are made of previous parameters and new `id` parameter.