### PR TITLE
Fixed create connect Url port

### DIFF
--- a/lib/src/http_connection.dart
+++ b/lib/src/http_connection.dart
@@ -454,11 +454,12 @@ class HttpConnection implements Connection {
     return Uri(
       scheme: uri.scheme,
       host: uri.host,
+      port: uri.port,
       path: uri.path,
       fragment: uri.fragment,
       queryParameters: <String, dynamic>{
         ...uri.queryParameters,
-        ...{ 'id': connectionToken },
+        ...{'id': connectionToken},
       },
     ).toString();
   }


### PR DESCRIPTION
#26 introduced a crucial bug that initializes a new Uri without a port (initialization with fallback port 0). Therefore the generated Uri is not usable.