### PR TITLE
Adding possibility for custom headers in the initial HTTP Request

### DIFF
--- a/lib/src/http_connection.dart
+++ b/lib/src/http_connection.dart
@@ -402,6 +402,10 @@ class HttpConnection implements Connection {
         headers['Authorization'] = 'Bearer $token';
       }
     }
+    
+    if (_options.customHeaders != null) {
+      headers.addAll(_options.customHeaders!);
+    }
 
     final negotiateUrl = _resolveNegotiateUrl(url);
     _logging!(LogLevel.debug, 'Sending negotiation request: $negotiateUrl.');

--- a/lib/src/http_connection_options.dart
+++ b/lib/src/http_connection_options.dart
@@ -12,6 +12,7 @@ class HttpConnectionOptions {
     this.logMessageContent = false,
     this.skipNegotiation = false,
     this.withCredentials = true,
+    this.customHeaders
   });
 
   /// An [BaseClient] that will be used to make HTTP requests.
@@ -24,6 +25,9 @@ class HttpConnectionOptions {
   ///
   /// Provide an [Logger] instance, and log messages will be logged via that instance.
   final Logging? logging;
+  
+  // custom headers sent with the negotiating HTTP request
+  final Map<String, String>? customHeaders;
 
   /// A function that provides an access token required for HTTP Bearer authentication.
   ///


### PR DESCRIPTION
In my project I need the possibility to send a custom header which is needed for authentication so I extended the library to consume option custom headers. They are attached to the HTTP request in the same manner as the Authentication header from the token factory is added.