### PR TITLE
Bump dart and package versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,17 +4,20 @@ version: 1.1.1
 homepage: https://github.com/jamiewest/signalr_core
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  http: ^0.13.0
-  logging: ^1.0.0
-  meta: ^1.3.0
-  tuple: ^2.0.0
-  web_socket_channel: ^2.0.0
-  sse_client: ^0.1.0
-  equatable: ^2.0.0
+  http: ^1.1.0
+  logging: ^1.2.0
+  meta: ^1.9.1
+  tuple: ^2.0.2
+  web_socket_channel: ^2.4.0
+  sse_channel:
+    git: 
+      url: https://github.com/RCSandberg/sse_channel.git
+      ref: feature/bump-dart-and-package-versions
+  equatable: ^2.0.5
 
 dev_dependencies:
-  pedantic: ^1.11.0
-  test: ^1.16.5
+  lints: ^2.1.1
+  test: ^1.24.4


### PR DESCRIPTION
- Use latest versions for each package
- Replace pedantic (deprecated) with lints
- Replace sse_client with sse_channel as that was listed as deprecated
- Temporarily point to sse_channel fork
  - When sse_channel fork is approved, a new commit should clean this up and convert this draft PR to a real PR